### PR TITLE
Rename classes and files

### DIFF
--- a/MobilePay-Apple.xcodeproj/project.pbxproj
+++ b/MobilePay-Apple.xcodeproj/project.pbxproj
@@ -7,14 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		FA3DF19226A831CF00111746 /* PaymentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3DF19126A831CF00111746 /* PaymentViewModel.swift */; };
-		FA3DF19326A831CF00111746 /* PaymentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3DF19126A831CF00111746 /* PaymentViewModel.swift */; };
+		FA3DF19226A831CF00111746 /* ProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3DF19126A831CF00111746 /* ProductListViewModel.swift */; };
+		FA3DF19326A831CF00111746 /* ProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3DF19126A831CF00111746 /* ProductListViewModel.swift */; };
 		FA5DF9BA26A567B600664755 /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF9B926A567B600664755 /* Tests_iOS.swift */; };
 		FA5DF9C526A567B600664755 /* Tests_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF9C426A567B600664755 /* Tests_macOS.swift */; };
 		FA5DF9C726A567B600664755 /* MobilePay_AppleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF99E26A567B500664755 /* MobilePay_AppleApp.swift */; };
 		FA5DF9C826A567B600664755 /* MobilePay_AppleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF99E26A567B500664755 /* MobilePay_AppleApp.swift */; };
-		FA5DF9C926A567B600664755 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF99F26A567B500664755 /* ContentView.swift */; };
-		FA5DF9CA26A567B600664755 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF99F26A567B500664755 /* ContentView.swift */; };
+		FA5DF9C926A567B600664755 /* ProductList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF99F26A567B500664755 /* ProductList.swift */; };
+		FA5DF9CA26A567B600664755 /* ProductList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF99F26A567B500664755 /* ProductList.swift */; };
 		FA5DF9CB26A567B600664755 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA5DF9A026A567B600664755 /* Assets.xcassets */; };
 		FA5DF9CC26A567B600664755 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA5DF9A026A567B600664755 /* Assets.xcassets */; };
 		FAB50D3026A578030093D56F /* MobilePayKit in Frameworks */ = {isa = PBXBuildFile; productRef = FAB50D2F26A578030093D56F /* MobilePayKit */; };
@@ -41,9 +41,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		FA3DF19126A831CF00111746 /* PaymentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentViewModel.swift; sourceTree = "<group>"; };
+		FA3DF19126A831CF00111746 /* ProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewModel.swift; sourceTree = "<group>"; };
 		FA5DF99E26A567B500664755 /* MobilePay_AppleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePay_AppleApp.swift; sourceTree = "<group>"; };
-		FA5DF99F26A567B500664755 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		FA5DF99F26A567B500664755 /* ProductList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductList.swift; sourceTree = "<group>"; };
 		FA5DF9A026A567B600664755 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FA5DF9A526A567B600664755 /* MobilePay-Apple.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MobilePay-Apple.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA5DF9A826A567B600664755 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -112,8 +112,8 @@
 			isa = PBXGroup;
 			children = (
 				FA5DF99E26A567B500664755 /* MobilePay_AppleApp.swift */,
-				FA3DF19126A831CF00111746 /* PaymentViewModel.swift */,
-				FA5DF99F26A567B500664755 /* ContentView.swift */,
+				FA3DF19126A831CF00111746 /* ProductListViewModel.swift */,
+				FA5DF99F26A567B500664755 /* ProductList.swift */,
 				FA5DF9A026A567B600664755 /* Assets.xcassets */,
 				FAB50D3926A57A460093D56F /* Configuration.storekit */,
 			);
@@ -360,8 +360,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA5DF9C926A567B600664755 /* ContentView.swift in Sources */,
-				FA3DF19226A831CF00111746 /* PaymentViewModel.swift in Sources */,
+				FA5DF9C926A567B600664755 /* ProductList.swift in Sources */,
+				FA3DF19226A831CF00111746 /* ProductListViewModel.swift in Sources */,
 				FA5DF9C726A567B600664755 /* MobilePay_AppleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -370,8 +370,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA5DF9CA26A567B600664755 /* ContentView.swift in Sources */,
-				FA3DF19326A831CF00111746 /* PaymentViewModel.swift in Sources */,
+				FA5DF9CA26A567B600664755 /* ProductList.swift in Sources */,
+				FA3DF19326A831CF00111746 /* ProductListViewModel.swift in Sources */,
 				FA5DF9C826A567B600664755 /* MobilePay_AppleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MobilePayKit/Sources/MobilePayKit/Models/Product.swift
+++ b/MobilePayKit/Sources/MobilePayKit/Models/Product.swift
@@ -1,7 +1,7 @@
 import Foundation
 import StoreKit
 
-public struct PurchasableContent: Hashable {
+public struct Product: Hashable {
     public let id: String
     public let title: String
     public let description: String

--- a/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
+++ b/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
@@ -18,7 +18,7 @@ public class PaymentManager: NSObject {
 
     // MARK: - Public
 
-    public func fetchProducts(completion: @escaping FetchCompletionCallback) {
+    public func fetchRemoteProducts(completion: @escaping FetchCompletionCallback) {
         paymentQueueService.fetchProducts(for: productIdentifiers, completion: completion)
     }
 

--- a/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
+++ b/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
@@ -21,14 +21,14 @@ public class PaymentManager: NSObject {
     public func fetchProducts(completion: @escaping FetchCompletionCallback) {
         paymentQueueService.fetchProducts(for: productIdentifiers, completion: completion)
     }
-    
+
     public func purchaseProduct(with identifier: String, completion: @escaping PurchaseCompletionCallback) {
-        
+
         // Check if the product exists in the App Store before purchasing
         guard let product = paymentQueueService.fetchProduct(for: identifier) else {
             return
         }
-        
+
         paymentQueueService.purchaseProduct(product, completion: completion)
 
     }

--- a/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
+++ b/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
@@ -18,7 +18,7 @@ public class PaymentManager: NSObject {
 
     // MARK: - Public
 
-    public func fetchRemoteProducts(completion: @escaping FetchCompletionCallback) {
+    public func fetchProducts(completion: @escaping FetchCompletionCallback) {
         paymentQueueService.fetchProducts(for: productIdentifiers, completion: completion)
     }
     

--- a/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
+++ b/MobilePayKit/Sources/MobilePayKit/PaymentManager.swift
@@ -21,13 +21,16 @@ public class PaymentManager: NSObject {
     public func fetchRemoteProducts(completion: @escaping FetchCompletionCallback) {
         paymentQueueService.fetchProducts(for: productIdentifiers, completion: completion)
     }
-
-    public func fetchProduct(for identifier: String) -> SKProduct? {
-        return paymentQueueService.fetchProduct(for: identifier)
-    }
-
-    public func purchaseProduct(_ product: SKProduct, completion: @escaping PurchaseCompletionCallback) {
+    
+    public func purchaseProduct(with identifier: String, completion: @escaping PurchaseCompletionCallback) {
+        
+        // Check if the product exists in the App Store before purchasing
+        guard let product = paymentQueueService.fetchProduct(for: identifier) else {
+            return
+        }
+        
         paymentQueueService.purchaseProduct(product, completion: completion)
+
     }
 
     public func restorePurchases() {

--- a/Shared/MobilePay_AppleApp.swift
+++ b/Shared/MobilePay_AppleApp.swift
@@ -4,11 +4,11 @@ import MobilePayKit
 @main
 struct MobilePay_AppleApp: App {
 
-    @StateObject private var viewModel = PaymentViewModel()
+    @StateObject private var viewModel = ProductListViewModel()
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ProductList()
                 .environmentObject(viewModel)
         }
     }

--- a/Shared/ProductList.swift
+++ b/Shared/ProductList.swift
@@ -85,7 +85,7 @@ struct ProductList: View {
                         }
                     } else {
                         ProductRow(product: product) {
-                            viewModel.buyProduct(with: product.id)
+                            viewModel.purchaseProduct(with: product.id)
                         }
                     }
                 }.navigationBarItems(trailing: Button("Restore") {

--- a/Shared/ProductList.swift
+++ b/Shared/ProductList.swift
@@ -1,38 +1,38 @@
 import SwiftUI
 import MobilePayKit
 
-struct PurchasableContentRow: View {
+struct ProductRow: View {
 
-    let content: PurchasableContent
+    let product: Product
     let action: () -> Void
 
     var body: some View {
         HStack {
             ZStack {
-                Image(content.imageName)
+                Image(product.imageName)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 80, height: 80)
                     .cornerRadius(9)
-                    .opacity(content.isLocked ? 0.8 : 1)
-                    .blur(radius: content.isLocked ? 3.0 : 0)
+                    .opacity(product.isLocked ? 0.8 : 1)
+                    .blur(radius: product.isLocked ? 3.0 : 0)
                     .padding()
 
                 Image(systemName: "lock.fill")
                     .font(.largeTitle)
-                    .opacity(content.isLocked ? 1 : 0)
+                    .opacity(product.isLocked ? 1 : 0)
             }
 
             VStack(alignment: .leading) {
-                Text(content.title)
+                Text(product.title)
                     .font(.headline)
-                Text(content.description)
+                Text(product.description)
                     .font(.caption)
             }
 
             Spacer()
 
-            if let price = content.price, content.isLocked {
+            if let price = product.price, product.isLocked {
                 Button(action: action, label: {
                     Text(price)
                         .foregroundColor(.white)
@@ -47,16 +47,16 @@ struct PurchasableContentRow: View {
 
 }
 
-struct PurchasableContentDetail: View {
+struct ProductDetail: View {
 
-    let content: PurchasableContent
+    let product: Product
 
     @Environment(\.presentationMode) var presentation
 
     var body: some View {
         NavigationView {
             VStack(alignment: .center) {
-                Image(content.imageName)
+                Image(product.imageName)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 256, height: 256)
@@ -64,28 +64,28 @@ struct PurchasableContentDetail: View {
                     .padding()
             }
 
-        }.navigationTitle(content.title)
+        }.navigationTitle(product.title)
     }
 }
 
-struct ContentView: View {
+struct ProductList: View {
 
-    @EnvironmentObject private var viewModel: PaymentViewModel
+    @EnvironmentObject private var viewModel: ProductListViewModel
 
     var body: some View {
         NavigationView {
-            List(viewModel.contentList, id: \.self) { content in
+            List(viewModel.products, id: \.self) { product in
                 Group {
-                    if !content.isLocked {
+                    if !product.isLocked {
 
-                        NavigationLink(destination: PurchasableContentDetail(content: content)) {
+                        NavigationLink(destination: ProductDetail(product: product)) {
 
                             // Content is already unlocked - nothing to see here
-                            PurchasableContentRow(content: content) { }
+                            ProductRow(product: product) { }
                         }
                     } else {
-                        PurchasableContentRow(content: content) {
-                            viewModel.buyProduct(with: content.id)
+                        ProductRow(product: product) {
+                            viewModel.buyProduct(with: product.id)
                         }
                     }
                 }.navigationBarItems(trailing: Button("Restore") {
@@ -96,8 +96,8 @@ struct ContentView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
+struct ProductList_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ProductList()
     }
 }

--- a/Shared/ProductListViewModel.swift
+++ b/Shared/ProductListViewModel.swift
@@ -38,13 +38,8 @@ class ProductListViewModel: ObservableObject {
         })
     }
 
-    func buyProduct(with identifier: String) {
-        // Check if the product exists before purchasing
-        guard let product = paymentManager.fetchProduct(for: identifier) else {
-            return
-        }
-
-        paymentManager.purchaseProduct(product, completion: { [weak self] transaction in
+    func purchaseProduct(with identifier: String) {
+        paymentManager.purchaseProduct(with: identifier, completion: { [weak self] transaction in
             guard let transaction = transaction else {
                 return
             }

--- a/Shared/ProductListViewModel.swift
+++ b/Shared/ProductListViewModel.swift
@@ -33,7 +33,7 @@ class ProductListViewModel: ObservableObject {
         self.products = []
         self.paymentManager = paymentManager
 
-        paymentManager.fetchProducts(completion: { products in
+        paymentManager.fetchRemoteProducts(completion: { products in
             self.products = products.map { Product(product: $0) }
         })
     }

--- a/Shared/ProductListViewModel.swift
+++ b/Shared/ProductListViewModel.swift
@@ -2,9 +2,9 @@ import Combine
 import Foundation
 import MobilePayKit
 
-class PaymentViewModel: ObservableObject {
+class ProductListViewModel: ObservableObject {
 
-    @Published private(set) var contentList: [PurchasableContent]
+    @Published private(set) var products: [MobilePayKit.Product]
 
     private let paymentManager: PaymentManager
 
@@ -20,21 +20,21 @@ class PaymentViewModel: ObservableObject {
                     return
                 }
 
-                for index in self.contentList.indices {
+                for index in self.products.indices {
 
                     // Update the "isLocked" if the product has been purchased
-                    self.contentList[index].isLocked = !self.completedPurchases.contains( self.contentList[index].id )
+                    self.products[index].isLocked = !self.completedPurchases.contains( self.products[index].id )
                 }
             }
         }
     }
 
     init(paymentManager: PaymentManager = .init()) {
-        self.contentList = []
+        self.products = []
         self.paymentManager = paymentManager
 
         paymentManager.fetchProducts(completion: { products in
-            self.contentList = products.map { PurchasableContent(product: $0) }
+            self.products = products.map { Product(product: $0) }
         })
     }
 

--- a/Shared/ProductListViewModel.swift
+++ b/Shared/ProductListViewModel.swift
@@ -33,7 +33,7 @@ class ProductListViewModel: ObservableObject {
         self.products = []
         self.paymentManager = paymentManager
 
-        paymentManager.fetchRemoteProducts(completion: { products in
+        paymentManager.fetchProducts(completion: { products in
             self.products = products.map { Product(product: $0) }
         })
     }


### PR DESCRIPTION
## Description

This PR renames some classes and files:
- `PurchasableContent` -> `Product`
- `ContentView` -> `ProductList`
- `PurchasableContentRow` -> `ProductRow`
- `PurchasableContentDetail` -> `ProductDetail`
- `PaymentViewModel` -> `ProductListViewModel`

## Notes
- This PR doesn't add any new functionality. I just made a dedicated PR to rename some things in order make future PRs easier to review.

## How to test 

1. Go to Edit Scheme > Run > Options > StoreKit Configuration
2. Choose `Configuration.storekit`
3. Run the iOS app
4. Tap on Rocket Fuel to purchase
5. Tap Confirm
6. Tap OK
7. On Xcode debugger menu, click on the Manage StoreKit Transactions menu item (See example below)

<img width="536" alt="Screen Shot 2021-07-19 at 16 29 19" src="https://user-images.githubusercontent.com/6711616/126186328-1bc968f4-8c18-45ad-84f1-b5033fc1cbe7.png">

8. ✅ There should be a record of Rocket Fuel being purchased (See example below)

<img width="747" alt="Screen Shot 2021-07-19 at 16 32 32" src="https://user-images.githubusercontent.com/6711616/126186582-3f76559e-7fe5-45ae-9068-2754883f6351.png">