### PR TITLE
Fix: remove h and m files from sources

### DIFF
--- a/MobilePayKit.podspec
+++ b/MobilePayKit.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   s.source        = { :git => 'https://github.com/Automattic/MobilePay-Apple.git', :tag => s.version.to_s }
-  s.module_name = "MobilePayKit"
-  s.source_files = 'Source/**/*.{h,m,swift}'
+  s.source_files = 'Source/**/*.{swift}'
 
 end


### PR DESCRIPTION
Removed h and m files from Cocoapods to avoid issues related to Obj-C