### PR TITLE
Inject siteId

### DIFF
--- a/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
+++ b/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
@@ -30,8 +30,7 @@ class ProductListViewModel: ObservableObject {
     init() {
         MobilePayKit.configure(
             oAuthToken: "token",
-            bundleId: Bundle.main.bundleIdentifier,
-            siteId: "siteID"
+            bundleId: Bundle.main.bundleIdentifier
         )
 
         MobilePayKit.shared.fetchProducts(completion: { products in

--- a/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
+++ b/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
@@ -30,7 +30,8 @@ class ProductListViewModel: ObservableObject {
     init() {
         MobilePayKit.configure(
             oAuthToken: "token",
-            bundleId: Bundle.main.bundleIdentifier
+            bundleId: Bundle.main.bundleIdentifier,
+            siteId: "siteID"
         )
 
         MobilePayKit.shared.fetchProducts(completion: { products in

--- a/Source/MobilePayKit.swift
+++ b/Source/MobilePayKit.swift
@@ -4,9 +4,9 @@ import StoreKit
 public struct MobilePayKitConfiguration {
     public let oAuthToken: String
     public let bundleId: String?
-    public let siteId: String?
+    public let siteId: Int?
 
-    public init(oAuthToken: String, bundleId: String?, siteId: String?) {
+    public init(oAuthToken: String, bundleId: String?, siteId: Int?) {
         self.oAuthToken = oAuthToken
         self.bundleId = bundleId
         self.siteId = siteId
@@ -32,7 +32,7 @@ public class MobilePayKit: NSObject {
 
     // MARK: - Public
 
-    public static func configure(oAuthToken: String, bundleId: String?, siteId: String? = nil) {
+    public static func configure(oAuthToken: String, bundleId: String?, siteId: Int? = nil) {
         let configuration = MobilePayKitConfiguration(oAuthToken: oAuthToken, bundleId: bundleId, siteId: siteId)
         _ = MobilePayKit(configuration: configuration)
     }

--- a/Source/MobilePayKit.swift
+++ b/Source/MobilePayKit.swift
@@ -4,9 +4,9 @@ import StoreKit
 public struct MobilePayKitConfiguration {
     public let oAuthToken: String
     public let bundleId: String?
-    public let siteId: String
+    public let siteId: String?
 
-    public init(oAuthToken: String, bundleId: String?, siteId: String) {
+    public init(oAuthToken: String, bundleId: String?, siteId: String?) {
         self.oAuthToken = oAuthToken
         self.bundleId = bundleId
         self.siteId = siteId
@@ -32,7 +32,7 @@ public class MobilePayKit: NSObject {
 
     // MARK: - Public
 
-    public static func configure(oAuthToken: String, bundleId: String?, siteId: String) {
+    public static func configure(oAuthToken: String, bundleId: String?, siteId: String? = nil) {
         let configuration = MobilePayKitConfiguration(oAuthToken: oAuthToken, bundleId: bundleId, siteId: siteId)
         _ = MobilePayKit(configuration: configuration)
     }

--- a/Source/MobilePayKit.swift
+++ b/Source/MobilePayKit.swift
@@ -4,10 +4,12 @@ import StoreKit
 public struct MobilePayKitConfiguration {
     public let oAuthToken: String
     public let bundleId: String?
+    public let siteId: String
 
-    public init(oAuthToken: String, bundleId: String?) {
+    public init(oAuthToken: String, bundleId: String?, siteId: String) {
         self.oAuthToken = oAuthToken
         self.bundleId = bundleId
+        self.siteId = siteId
     }
 }
 
@@ -30,8 +32,8 @@ public class MobilePayKit: NSObject {
 
     // MARK: - Public
 
-    public static func configure(oAuthToken: String, bundleId: String?) {
-        let configuration = MobilePayKitConfiguration(oAuthToken: oAuthToken, bundleId: bundleId    )
+    public static func configure(oAuthToken: String, bundleId: String?, siteId: String) {
+        let configuration = MobilePayKitConfiguration(oAuthToken: oAuthToken, bundleId: bundleId, siteId: siteId)
         _ = MobilePayKit(configuration: configuration)
     }
 

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -178,7 +178,7 @@ extension AppStoreService: SKPaymentTransactionObserver {
         let country = paymentQueue.storefront?.countryCode ?? ""
 
         iapService.createOrder(
-            identifier: product.productIdentifier,
+            orderId: product.productIdentifier,
             price: product.priceInCents,
             country: country,
             receipt: receipt

--- a/Source/Services/InAppPurchasesAPIRouter.swift
+++ b/Source/Services/InAppPurchasesAPIRouter.swift
@@ -64,7 +64,7 @@ enum InAppPurchasesAPIRouter: URLRequestConvertible {
 }
 
 struct CreateOrderParameters: Encodable {
-    let site_id: String?
+    let site_id: Int?
     let product_id: String
     let price: Int
     let appstore_country: String

--- a/Source/Services/InAppPurchasesAPIRouter.swift
+++ b/Source/Services/InAppPurchasesAPIRouter.swift
@@ -64,7 +64,7 @@ enum InAppPurchasesAPIRouter: URLRequestConvertible {
 }
 
 struct CreateOrderParameters: Encodable {
-    let site_id: String
+    let site_id: String?
     let product_id: String
     let price: Int
     let appstore_country: String

--- a/Source/Services/InAppPurchasesAPIRouter.swift
+++ b/Source/Services/InAppPurchasesAPIRouter.swift
@@ -64,6 +64,7 @@ enum InAppPurchasesAPIRouter: URLRequestConvertible {
 }
 
 struct CreateOrderParameters: Encodable {
+    let site_id: String
     let product_id: String
     let price: Int
     let appstore_country: String

--- a/Source/Services/InAppPurchasesService.swift
+++ b/Source/Services/InAppPurchasesService.swift
@@ -29,6 +29,7 @@ class InAppPurchasesService: InAppPurchasesServiceProtocol {
     func createOrder(orderId: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error> {
 
         let parameters = CreateOrderParameters(
+            site_id: configuration.siteId,
             product_id: orderId,
             price: price,
             appstore_country: country,

--- a/Source/Services/InAppPurchasesService.swift
+++ b/Source/Services/InAppPurchasesService.swift
@@ -3,7 +3,7 @@ import Foundation
 
 protocol InAppPurchasesServiceProtocol {
     func fetchProductSKUs() -> AnyPublisher<[String], Error>
-    func createOrder(identifier: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error>
+    func createOrder(orderId: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error>
 }
 
 class InAppPurchasesService: InAppPurchasesServiceProtocol {
@@ -26,10 +26,10 @@ class InAppPurchasesService: InAppPurchasesServiceProtocol {
             .eraseToAnyPublisher()
     }
 
-    func createOrder(identifier: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error> {
+    func createOrder(orderId: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error> {
 
         let parameters = CreateOrderParameters(
-            product_id: identifier,
+            product_id: orderId,
             price: price,
             appstore_country: country,
             apple_receipt: receipt

--- a/Tests/InAppPurchasesServiceTests.swift
+++ b/Tests/InAppPurchasesServiceTests.swift
@@ -85,7 +85,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Publishes decoded Int")
 
-        service.createOrder(identifier: "1", price: 100, country: "", receipt: "")
+        service.createOrder(orderId: "1", price: 100, country: "", receipt: "")
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { orderId in
@@ -109,7 +109,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Publishes received URLError")
 
-        service.createOrder(identifier: "1", price: 100, country: "", receipt: "")
+        service.createOrder(orderId: "1", price: 100, country: "", receipt: "")
             .sink(
                 receiveCompletion: { completion in
                     guard case .failure(let error) = completion else {

--- a/Tests/MobilePayKitConfiguration+Fixture.swift
+++ b/Tests/MobilePayKitConfiguration+Fixture.swift
@@ -4,8 +4,9 @@ extension MobilePayKitConfiguration {
 
     static func fixture(
         oAuthToken: String = "token",
-        bundleId: String? = ""
+        bundleId: String? = "",
+        siteId: String = "123"
     ) -> MobilePayKitConfiguration {
-        return MobilePayKitConfiguration(oAuthToken: oAuthToken, bundleId: bundleId)
+        return MobilePayKitConfiguration(oAuthToken: oAuthToken, bundleId: bundleId, siteId: siteId)
     }
 }


### PR DESCRIPTION
## Description
This PR injects the site id into MobilePayKit.

## Notes
Apply patch to test the new createOrders endpoint (D65254-code)

For sandbox info, follow instructions in these posts:
- pbMoDN-mH-p2
- pbArwn-24D-p2

## How to test

### Running tests
1. Run MobilePayKitTests test target
2. ✅ Tests should pass

### Running the app

1. Configure the bearer token and site id in `ProductListViewModel`

https://github.com/Automattic/MobilePay-Apple/blob/03400b306c01ab8b1108302885577f5fca252157/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift#L31-L35

2. Run the iOS app
3. Purchase the product by tapping on it
4. Tap Confirm
5. Tap OK
6. On Xcode debugger menu, click on the Manage StoreKit Transactions menu item 
7. ✅ There should be a record of a product being purchased (See example below)

<img width="747" alt="Screen Shot 2021-07-19 at 16 32 32" src="https://user-images.githubusercontent.com/6711616/126186582-3f76559e-7fe5-45ae-9068-2754883f6351.png">

