### PR TITLE
Change completion callback param to Result<T, Error>

### DIFF
--- a/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
+++ b/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
@@ -33,10 +33,10 @@ class ProductListViewModel: ObservableObject {
             bundleId: Bundle.main.bundleIdentifier
         )
 
-        MobilePayKit.shared.fetchProducts { result in
+        MobilePayKit.shared.fetchProducts { [weak self] result in
             switch result {
             case .success(let products):
-                self.products = products.map { Product(product: $0) }
+                self?.products = products.map { Product(product: $0) }
             case .failure(let error):
                 print("Error fetching products: \(error.localizedDescription)")
             }

--- a/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
+++ b/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
@@ -33,17 +33,24 @@ class ProductListViewModel: ObservableObject {
             bundleId: Bundle.main.bundleIdentifier
         )
 
-        MobilePayKit.shared.fetchProducts(completion: { products in
-            self.products = products.map { Product(product: $0) }
+        MobilePayKit.shared.fetchProducts(completion: { result in
+            switch result {
+            case .success(let products):
+                self.products = products.map { Product(product: $0) }
+            case .failure(let error):
+                print("Error fetching products: \(error.localizedDescription)")
+            }
         })
     }
 
     func purchaseProduct(with identifier: String) {
-        MobilePayKit.shared.purchaseProduct(with: identifier, completion: { [weak self] transaction in
-            guard let transaction = transaction else {
-                return
+        MobilePayKit.shared.purchaseProduct(with: identifier, completion: { [weak self] result in
+            switch result {
+            case .success(let transaction):
+                self?.completedPurchases.append(transaction.payment.productIdentifier)
+            case .failure(let error):
+                print("Error purchasing product: \(error.localizedDescription)")
             }
-            self?.completedPurchases.append(transaction.payment.productIdentifier)
         })
     }
 

--- a/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
+++ b/Example/iOS/MobilePayKit-iOS/ProductListViewModel.swift
@@ -33,25 +33,25 @@ class ProductListViewModel: ObservableObject {
             bundleId: Bundle.main.bundleIdentifier
         )
 
-        MobilePayKit.shared.fetchProducts(completion: { result in
+        MobilePayKit.shared.fetchProducts { result in
             switch result {
             case .success(let products):
                 self.products = products.map { Product(product: $0) }
             case .failure(let error):
                 print("Error fetching products: \(error.localizedDescription)")
             }
-        })
+        }
     }
 
     func purchaseProduct(with identifier: String) {
-        MobilePayKit.shared.purchaseProduct(with: identifier, completion: { [weak self] result in
+        MobilePayKit.shared.purchaseProduct(with: identifier) { [weak self] result in
             switch result {
             case .success(let transaction):
                 self?.completedPurchases.append(transaction.payment.productIdentifier)
             case .failure(let error):
                 print("Error purchasing product: \(error.localizedDescription)")
             }
-        })
+        }
     }
 
     func restorePurchases() {

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -2,8 +2,11 @@ import Combine
 import Foundation
 import StoreKit
 
-public typealias FetchCompletionCallback = (Result<[SKProduct], Error>) -> Void
-public typealias PurchaseCompletionCallback = (Result<SKPaymentTransaction, Error>) -> Void
+public typealias FetchCompletionCallback = (ProductsResult) -> Void
+public typealias PurchaseCompletionCallback = (TransactionResult) -> Void
+
+public typealias ProductsResult = Result<[SKProduct], Error>
+public typealias TransactionResult = Result<SKPaymentTransaction, Error>
 
 public protocol AppStoreServiceProtocol {
     func fetchProducts(completion: @escaping FetchCompletionCallback)
@@ -215,7 +218,7 @@ extension AppStoreService: SKPaymentTransactionObserver {
         .store(in: &cancellables)
     }
 
-    private func performPurchaseCompletionCallback(_ result: Result<SKPaymentTransaction, Error>) {
+    private func performPurchaseCompletionCallback(_ result: TransactionResult) {
         DispatchQueue.main.async {
             self.purchaseCompletionCallback?(result)
             self.purchaseCompletionCallback = nil

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -132,8 +132,17 @@ extension AppStoreService: SKPaymentTransactionObserver {
     }
 
     private func handleFailedTransaction(_ transaction: SKPaymentTransaction) {
-        // FIXME: handle failed transaction
+
+        guard let error = transaction.error else {
+            return
+        }
+
         paymentQueue.finishTransaction(transaction)
+
+        DispatchQueue.main.async {
+            self.purchaseCompletionCallback?(.failure(error))
+            self.purchaseCompletionCallback = nil
+        }
     }
 
     private func handleCompletedTransaction(_ transaction: SKPaymentTransaction) {

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -182,13 +182,16 @@ extension AppStoreService: SKPaymentTransactionObserver {
             price: product.priceInCents,
             country: country,
             receipt: receipt
-        ).sink(receiveCompletion: { completion in
+        ).sink(receiveCompletion: { [weak self] completion in
 
             switch completion {
             case .finished:
                 print("create order finished")
             case .failure(let error):
-                print("create order error: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self?.purchaseCompletionCallback?(.failure(error))
+                    self?.purchaseCompletionCallback = nil
+                }
             }
 
         }, receiveValue: { [weak self] orderId in

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -64,9 +64,9 @@ public class AppStoreService: NSObject, AppStoreServiceProtocol {
     public func fetchProducts(completion: @escaping FetchCompletionCallback) {
         iapService.fetchProductSKUs()
             .sink(
-                receiveCompletion: { fetchSkusCompletion in
+                receiveCompletion: { fetchSKUsCompletion in
 
-                    switch fetchSkusCompletion {
+                    switch fetchSKUsCompletion {
                     case .finished:
                         print("fetch products finished")
                     case .failure(let error):

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -14,7 +14,7 @@ public protocol AppStoreServiceProtocol {
 
 public class AppStoreService: NSObject, AppStoreServiceProtocol {
 
-    private let iapService: InAppPurchasesService
+    private let iapService: InAppPurchasesServiceProtocol
 
     private let paymentQueue: PaymentQueue
 
@@ -35,7 +35,7 @@ public class AppStoreService: NSObject, AppStoreServiceProtocol {
 
     init(
         configuration: MobilePayKitConfiguration,
-        iapService: InAppPurchasesService? = nil,
+        iapService: InAppPurchasesServiceProtocol? = nil,
         paymentQueue: PaymentQueue = SKPaymentQueue.default(),
         productsRequestFactory: ProductsRequestFactory = AppStoreProductsRequestFactory()
     ) {

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -53,15 +53,15 @@ public class AppStoreService: NSObject, AppStoreServiceProtocol {
     // MARK: - Public
 
     public func fetchProducts(completion: @escaping FetchCompletionCallback) {
-        iapService.fetchProductSKUs()
+        iapService.fetchProductSkus()
             .sink(
-                receiveCompletion: { completion in
+                receiveCompletion: { fetchSkusCompletion in
 
-                    switch completion {
+                    switch fetchSkusCompletion {
                     case .finished:
                         print("fetch products finished")
                     case .failure(let error):
-                        print("fetch products error: \(error.localizedDescription)")
+                        completion(.failure(error))
                     }
 
                 },

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -3,7 +3,7 @@ import Foundation
 import StoreKit
 
 public typealias FetchCompletionCallback = (Result<[SKProduct], Error>) -> Void
-public typealias PurchaseCompletionCallback = (SKPaymentTransaction?) -> Void
+public typealias PurchaseCompletionCallback = (Result<SKPaymentTransaction, Error>) -> Void
 
 public protocol AppStoreServiceProtocol {
     func fetchProducts(completion: @escaping FetchCompletionCallback)
@@ -199,7 +199,7 @@ extension AppStoreService: SKPaymentTransactionObserver {
             self?.paymentQueue.finishTransaction(transaction)
 
             DispatchQueue.main.async {
-                self?.purchaseCompletionCallback?(transaction)
+                self?.purchaseCompletionCallback?(.success(transaction))
                 self?.purchaseCompletionCallback = nil
             }
 

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -197,24 +197,28 @@ extension AppStoreService: SKPaymentTransactionObserver {
             price: product.priceInCents,
             country: country,
             receipt: receipt
-        ).sink(receiveCompletion: { [weak self] completion in
+        )
+        .sink(
+            receiveCompletion: { [weak self] completion in
 
-            switch completion {
-            case .finished:
-                print("create order finished")
-            case .failure(let error):
-                self?.performPurchaseCompletionCallback(.failure(error))
+                switch completion {
+                case .finished:
+                    print("create order finished")
+                case .failure(let error):
+                    self?.performPurchaseCompletionCallback(.failure(error))
+                }
+
+            },
+            receiveValue: { [weak self] orderId in
+
+                print("created order for: \(orderId)")
+
+                // Finish the transaction once we've successfully created an order remotely
+                self?.paymentQueue.finishTransaction(transaction)
+
+                self?.performPurchaseCompletionCallback(.success(transaction))
             }
-
-        }, receiveValue: { [weak self] orderId in
-
-            print("created order for: \(orderId)")
-
-            // Finish the transaction once we've successfully created an order remotely
-            self?.paymentQueue.finishTransaction(transaction)
-
-            self?.performPurchaseCompletionCallback(.success(transaction))
-        })
+        )
         .store(in: &cancellables)
     }
 

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 import StoreKit
 
-public typealias FetchCompletionCallback = ([SKProduct]) -> Void
+public typealias FetchCompletionCallback = (Result<[SKProduct], Error>) -> Void
 public typealias PurchaseCompletionCallback = (SKPaymentTransaction?) -> Void
 
 public protocol AppStoreServiceProtocol {

--- a/Source/Services/AppStoreService.swift
+++ b/Source/Services/AppStoreService.swift
@@ -62,7 +62,7 @@ public class AppStoreService: NSObject, AppStoreServiceProtocol {
     // MARK: - Public
 
     public func fetchProducts(completion: @escaping FetchCompletionCallback) {
-        iapService.fetchProductSkus()
+        iapService.fetchProductSKUs()
             .sink(
                 receiveCompletion: { fetchSkusCompletion in
 

--- a/Source/Services/InAppPurchasesService.swift
+++ b/Source/Services/InAppPurchasesService.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-protocol InAppPurchasesServiceProtocol {
+public protocol InAppPurchasesServiceProtocol {
     func fetchProductSkus() -> AnyPublisher<[String], Error>
     func createOrder(identifier: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error>
 }

--- a/Source/Services/InAppPurchasesService.swift
+++ b/Source/Services/InAppPurchasesService.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 public protocol InAppPurchasesServiceProtocol {
-    func fetchProductSkus() -> AnyPublisher<[String], Error>
+    func fetchProductSKUs() -> AnyPublisher<[String], Error>
     func createOrder(identifier: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error>
 }
 
@@ -17,7 +17,7 @@ class InAppPurchasesService: InAppPurchasesServiceProtocol {
         self.networking = networking
     }
 
-    func fetchProductSkus() -> AnyPublisher<[String], Error> {
+    func fetchProductSKUs() -> AnyPublisher<[String], Error> {
 
         let request = createURLRequest(for: .products)
 

--- a/Source/Services/InAppPurchasesService.swift
+++ b/Source/Services/InAppPurchasesService.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 protocol InAppPurchasesServiceProtocol {
-    func fetchProductSKUs() -> AnyPublisher<[String], Error>
+    func fetchProductSkus() -> AnyPublisher<[String], Error>
     func createOrder(identifier: String, price: Int, country: String, receipt: String) -> AnyPublisher<Int, Error>
 }
 
@@ -17,7 +17,7 @@ class InAppPurchasesService: InAppPurchasesServiceProtocol {
         self.networking = networking
     }
 
-    func fetchProductSKUs() -> AnyPublisher<[String], Error> {
+    func fetchProductSkus() -> AnyPublisher<[String], Error> {
 
         let request = createURLRequest(for: .products)
 

--- a/Source/Services/ProductsRequest/ProductsRequestHelper.swift
+++ b/Source/Services/ProductsRequest/ProductsRequestHelper.swift
@@ -55,7 +55,7 @@ extension ProductsRequestHelper: SKProductsRequestDelegate {
         fetchedProducts = products
 
         DispatchQueue.main.async { [weak self] in
-            self?.fetchCompletionCallback?(products)
+            self?.fetchCompletionCallback?(.success(products))
             self?.fetchCompletionCallback = nil
         }
     }

--- a/Source/Services/ProductsRequest/ProductsRequestHelper.swift
+++ b/Source/Services/ProductsRequest/ProductsRequestHelper.swift
@@ -59,4 +59,11 @@ extension ProductsRequestHelper: SKProductsRequestDelegate {
             self?.fetchCompletionCallback = nil
         }
     }
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        DispatchQueue.main.async { [weak self] in
+            self?.fetchCompletionCallback?(.failure(error))
+            self?.fetchCompletionCallback = nil
+        }
+    }
 }

--- a/Source/Services/ProductsRequest/ProductsRequestHelper.swift
+++ b/Source/Services/ProductsRequest/ProductsRequestHelper.swift
@@ -54,15 +54,16 @@ extension ProductsRequestHelper: SKProductsRequestDelegate {
         // Here we are caching the products
         fetchedProducts = products
 
-        DispatchQueue.main.async { [weak self] in
-            self?.fetchCompletionCallback?(.success(products))
-            self?.fetchCompletionCallback = nil
-        }
+        performFetchCompletionCallback(.success(products))
     }
 
     func request(_ request: SKRequest, didFailWithError error: Error) {
+        performFetchCompletionCallback(.failure(error))
+    }
+
+    private func performFetchCompletionCallback(_ result: Result<[SKProduct], Error>) {
         DispatchQueue.main.async { [weak self] in
-            self?.fetchCompletionCallback?(.failure(error))
+            self?.fetchCompletionCallback?(result)
             self?.fetchCompletionCallback = nil
         }
     }

--- a/Source/Services/ProductsRequest/ProductsRequestHelper.swift
+++ b/Source/Services/ProductsRequest/ProductsRequestHelper.swift
@@ -61,7 +61,7 @@ extension ProductsRequestHelper: SKProductsRequestDelegate {
         performFetchCompletionCallback(.failure(error))
     }
 
-    private func performFetchCompletionCallback(_ result: Result<[SKProduct], Error>) {
+    private func performFetchCompletionCallback(_ result: ProductsResult) {
         DispatchQueue.main.async { [weak self] in
             self?.fetchCompletionCallback?(result)
             self?.fetchCompletionCallback = nil

--- a/Tests/AppStoreServiceTests.swift
+++ b/Tests/AppStoreServiceTests.swift
@@ -70,8 +70,11 @@ final class AppStoreServiceTests: XCTestCase {
     // MARK: - Payment queue updated transactions
 
     func testPaymentQueueUpdatedTransactions_WhenTransactionStateIsFailed_CallsFinishTransaction() {
+
+        let error = NSError(domain: "", code: 0)
+
         let transactions: [TestPaymentTransaction] = [
-            .fixture(transactionState: .failed)
+            .fixture(transactionState: .failed, error: error)
         ]
 
         service.paymentQueue(SKPaymentQueue(), updatedTransactions: transactions)

--- a/Tests/InAppPurchasesServiceTests.swift
+++ b/Tests/InAppPurchasesServiceTests.swift
@@ -26,7 +26,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Publishes decoded [String]")
 
-        service.fetchProductSkus()
+        service.fetchProductSKUs()
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { productIds in
@@ -50,7 +50,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Publishes received URLError")
 
-        service.fetchProductSkus()
+        service.fetchProductSKUs()
             .sink(
                 receiveCompletion: { completion in
                     guard case .failure(let error) = completion else {

--- a/Tests/InAppPurchasesServiceTests.swift
+++ b/Tests/InAppPurchasesServiceTests.swift
@@ -7,7 +7,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
     var cancellables = Set<AnyCancellable>()
 
-    func testFetchProductSkus_WhenRequestSucceeds_PublishesDecodedSkus() throws {
+    func testFetchProductSKUs_WhenRequestSucceeds_PublishesDecodedSKUs() throws {
 
         let json = """
         [
@@ -39,7 +39,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testFetchProductSkus_WhenRequestFails_PublishesReceivedError() throws {
+    func testFetchProductSKUs_WhenRequestFails_PublishesReceivedError() throws {
 
         let expectedError = URLError(.badServerResponse)
 

--- a/Tests/InAppPurchasesServiceTests.swift
+++ b/Tests/InAppPurchasesServiceTests.swift
@@ -7,7 +7,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
     var cancellables = Set<AnyCancellable>()
 
-    func testFetchProducts_WhenReqeustSucceeds_PublishesDecodedSkus() throws {
+    func testFetchProductSkus_WhenRequestSucceeds_PublishesDecodedSkus() throws {
 
         let json = """
         [
@@ -39,7 +39,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testFetchProducts_WhenRequestFails_PublishesReceivedError() throws {
+    func testFetchProductSkus_WhenRequestFails_PublishesReceivedError() throws {
 
         let expectedError = URLError(.badServerResponse)
 
@@ -68,7 +68,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
             .store(in: &cancellables)
     }
 
-    func testCreateOrder_WhenReqeustSucceeds_PublishesDecodedOrderIds() throws {
+    func testCreateOrder_WhenRequestSucceeds_PublishesDecodedOrderIds() throws {
 
         let json = """
         {

--- a/Tests/InAppPurchasesServiceTests.swift
+++ b/Tests/InAppPurchasesServiceTests.swift
@@ -26,7 +26,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Publishes decoded [String]")
 
-        service.fetchProductSKUs()
+        service.fetchProductSkus()
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { productIds in
@@ -50,7 +50,7 @@ final class InAppPurchasesServiceTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Publishes received URLError")
 
-        service.fetchProductSKUs()
+        service.fetchProductSkus()
             .sink(
                 receiveCompletion: { completion in
                     guard case .failure(let error) = completion else {

--- a/Tests/TestPaymentTransaction+Fixture.swift
+++ b/Tests/TestPaymentTransaction+Fixture.swift
@@ -4,9 +4,15 @@ extension TestPaymentTransaction {
 
     static func fixture(
         productIdentifier: String = "com.mobilepaykit.product",
-        transactionState: SKPaymentTransactionState
+        transactionState: SKPaymentTransactionState,
+        error: Error? = nil
     ) -> TestPaymentTransaction {
         let testProduct = TestProduct(productIdentifier: productIdentifier)
-        return TestPaymentTransaction(payment: SKPayment(product: testProduct), transactionState: transactionState)
+
+        return TestPaymentTransaction(
+            payment: SKPayment(product: testProduct),
+            transactionState: transactionState,
+            error: error
+        )
     }
 }

--- a/Tests/TestPaymentTransaction.swift
+++ b/Tests/TestPaymentTransaction.swift
@@ -4,10 +4,12 @@ class TestPaymentTransaction: SKPaymentTransaction {
 
     let testPayment: SKPayment
     let testTransactionState: SKPaymentTransactionState
+    let testError: Error?
 
-    init(payment: SKPayment, transactionState: SKPaymentTransactionState) {
+    init(payment: SKPayment, transactionState: SKPaymentTransactionState, error: Error? = nil) {
         testPayment = payment
         testTransactionState = transactionState
+        testError = error
         super.init()
     }
 
@@ -17,5 +19,9 @@ class TestPaymentTransaction: SKPaymentTransaction {
 
     override var transactionState: SKPaymentTransactionState {
         return testTransactionState
+    }
+
+    override var error: Error? {
+        return testError
     }
 }


### PR DESCRIPTION
## Description

Resolves https://github.com/wordpress-mobile/WordPress-iOS/issues/17018

This PR updates the completion callback param to `Result<T, Error>`

- Added `PurchaseError`
- Added error handling for AppStoreService.fetchProducts via `SKProductsRequestDelegate` (when `
request(_:didFailWithError:) ` gets called)
- Added error handling for AppStoreService.purchaseProduct via `SKPaymentTransactionObserver` (when the updated transaction state is `.failed`)

## Notes

- InAppPurchasesService error handling tests already exist
  - `testFetchProductSkus_WhenRequestFails_PublishesReceivedError()`
  - `testCreateOrder_WhenRequestFails_PublishesReceivedError()`

## How to test

### Running tests
1. Run MobilePayKitTests test target
2. ✅ Tests should pass

### Running the app

1. Configure the bearer token in `ProductListViewModel`
2. Run the iOS app
3. Purchase the product by tapping on it
4. Tap Confirm
5. Tap OK
6. On Xcode debugger menu, click on the Manage StoreKit Transactions menu item 
7. ✅ There should be a record of a product being purchased (See example below)

<img width="747" alt="Screen Shot 2021-07-19 at 16 32 32" src="https://user-images.githubusercontent.com/6711616/126186582-3f76559e-7fe5-45ae-9068-2754883f6351.png">