### PR TITLE
Fix macOS build

### DIFF
--- a/Example/macOS/MobilePayKit-macOS/ProductList.swift
+++ b/Example/macOS/MobilePayKit-macOS/ProductList.swift
@@ -9,8 +9,9 @@ struct ProductRow: View {
     var body: some View {
         HStack {
             ZStack {
-                Image(product.imageName)
+                Image(systemName: "cart.fill")
                     .resizable()
+                    .foregroundColor(Color(.lightGray))
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 80, height: 80)
                     .cornerRadius(9)
@@ -63,8 +64,9 @@ struct ProductDetail: View {
     var body: some View {
         NavigationView {
             VStack(alignment: .center) {
-                Image(product.imageName)
+                Image(systemName: "cart.fill")
                     .resizable()
+                    .foregroundColor(Color(.lightGray))
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 256, height: 256)
                     .cornerRadius(9)


### PR DESCRIPTION
## Description
This PR fixes the macOS build

- Updated ProductListViewModel in the macOS target (copied / pasted from iOS target)
- Updated ProductList SwiftUI view in the macOS target

## How to test

### Running the app

1. Configure the bearer token and site id in `ProductListViewModel` for macOS
2. Run the macOS app
3. Purchase the product by tapping on it
4. Tap Confirm
5. Tap OK
6. On Xcode debugger menu, click on the Manage StoreKit Transactions menu item 
7. ✅ There should be a record of a product being purchased 

