### PR TITLE
[Tooling/CI] Update to latest bash-cache Buildkite plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#1.7.0: ~
+  - &bash_cache automattic/bash-cache#2.0.0: ~
   env: &common_env
     IMAGE_ID: xcode-12.5.1
 
@@ -12,14 +12,14 @@ steps:
   ################
   - label: "🧪 Build and Test iOS"
     key: "test-ios"
-    command: "build_and_test_pod 'ios test'"
+    command: "build_and_test_pod ios test"
     env: *common_env
     plugins: *common_plugins
     artifact_paths: ".build/logs/*.log"
 
   # - label: "🧪 Build and Test macOS"
   #   key: "test-macos"
-  #   command: "build_and_test_pod 'mac test'"
+  #   command: "build_and_test_pod mac test"
   #   env: *common_env
   #   plugins: *common_plugins
   #   artifact_paths: ".build/logs/*.log"


### PR DESCRIPTION
…  and fix breaking change in build_and_test_pod call

### To Test

Check that CI runs the unit tests as expected and still goes green.